### PR TITLE
EASY-2762: easy-add-files-to-bag uses default namespace when adding files to files.xml

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.file2bag/FilesXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.file2bag/FilesXmlSpec.scala
@@ -24,13 +24,13 @@ import scala.util.Success
 
 class FilesXmlSpec extends AnyFlatSpec with Matchers {
 
-  private val oldFilesXml =
+  private val filesXmlDcterms =
     <files xmlns:dcterms="http://purl.org/dc/terms/"
            xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
         <file filepath="data/path/to/file.txt">
-            <dc:format>text/plain</dc:format>
+            <dcterms:format>text/plain</dcterms:format>
             <accessibleToRights>NONE</accessibleToRights>
             <visibleToRights>RESTRICTED_REQUEST</visibleToRights>
         </file>
@@ -39,33 +39,66 @@ class FilesXmlSpec extends AnyFlatSpec with Matchers {
         </file>
     </files>
 
-  private val oldFilesXmlNoFileElements =
+  private val filesXmlDct =
+    <files xmlns:dct="http://purl.org/dc/terms/"
+           xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+        <file filepath="data/path/to/file.txt">
+            <dct:format>text/plain</dct:format>
+            <accessibleToRights>NONE</accessibleToRights>
+            <visibleToRights>RESTRICTED_REQUEST</visibleToRights>
+        </file>
+        <file filepath="data/quicksort.hs">
+            <dct:format>text/plain</dct:format>
+        </file>
+    </files>
+
+  private val filesXmlNoFileElements =
     <files xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
     </files>
 
-  "apply" should "add an item to files.xml" in {
+  "apply" should "add an item to files.xml with dcterms prefix in format tag" in {
     val triedNode = FilesXml(
-      oldFilesXml,
+      filesXmlDcterms,
       accessRights = "SOME", // garbage is validated in the App class
       mimeType = "text/plain",
       destinationPath = Paths.get("blabla.txt"),
     )
     triedNode shouldBe a[Success[_]]
     val newFileItems = triedNode.get \ "file"
-    newFileItems.theSeq.size shouldBe 1 + (oldFilesXml \ "file").theSeq.size
+    newFileItems.theSeq.size shouldBe 1 + (filesXmlDcterms \ "file").theSeq.size
     newFileItems.last.serialize shouldBe
       """<?xml version='1.0' encoding='UTF-8'?>
         |<file filepath="data/blabla.txt">
-        |  <dc:format>text/plain</dc:format>
+        |  <dcterms:format>text/plain</dcterms:format>
+        |  <accessibleToRights>SOME</accessibleToRights>
+        |</file>""".stripMargin
+  }
+
+  it should "add an item to files.xml with dct prefix in format tag" in {
+    val triedNode = FilesXml(
+      filesXmlDct,
+      accessRights = "SOME", // garbage is validated in the App class
+      mimeType = "text/plain",
+      destinationPath = Paths.get("blabla.txt"),
+    )
+    triedNode shouldBe a[Success[_]]
+    val newFileItems = triedNode.get \ "file"
+    newFileItems.theSeq.size shouldBe 1 + (filesXmlDct \ "file").theSeq.size
+    newFileItems.last.serialize shouldBe
+      """<?xml version='1.0' encoding='UTF-8'?>
+        |<file filepath="data/blabla.txt">
+        |  <dct:format>text/plain</dct:format>
         |  <accessibleToRights>SOME</accessibleToRights>
         |</file>""".stripMargin
   }
 
   it should "not provide default rights" in {
     val triedNode = FilesXml(
-      oldFilesXml,
+      filesXmlDcterms,
       accessRights = "",
       mimeType = "text/plain",
       destinationPath = Paths.get("blabla.txt"),
@@ -74,19 +107,19 @@ class FilesXmlSpec extends AnyFlatSpec with Matchers {
     (triedNode.get \ "file").last.serialize shouldBe
       """<?xml version='1.0' encoding='UTF-8'?>
         |<file filepath="data/blabla.txt">
-        |  <dc:format>text/plain</dc:format>
+        |  <dcterms:format>text/plain</dcterms:format>
         |</file>""".stripMargin
   }
 
-  it should "add a file element to files.xml, format node with 'dcterms' prefix" in {
+  it should "add a file element with dcterms prefix in format tag to an empty files.xml" in {
     val triedNode = FilesXml(
-      oldFilesXmlNoFileElements,
+      filesXmlNoFileElements,
       accessRights = "SOME",
       mimeType = "text/plain",
       destinationPath = Paths.get("blabla.txt"),
     )
     triedNode shouldBe a[Success[_]]
-    (triedNode.get \ "file").last.serialize shouldBe
+    (triedNode.get \ "file").head.serialize shouldBe
       """<?xml version='1.0' encoding='UTF-8'?>
         |<file filepath="data/blabla.txt">
         |  <dcterms:format>text/plain</dcterms:format>
@@ -96,12 +129,12 @@ class FilesXmlSpec extends AnyFlatSpec with Matchers {
 
   it should "add a namespace for the prefix 'dcterms'" in {
     val triedNode = FilesXml(
-      oldFilesXmlNoFileElements,
+      filesXmlNoFileElements,
       accessRights = "SOME",
       mimeType = "text/plain",
       destinationPath = Paths.get("blabla.txt"),
     )
-    oldFilesXmlNoFileElements.scope.getURI("dcterms") shouldBe null
+    filesXmlNoFileElements.scope.getURI("dcterms") shouldBe null
     triedNode shouldBe a[Success[_]]
     triedNode.get.scope.getURI("dcterms") should not be null
   }


### PR DESCRIPTION
Fixes EASY-2762

* Prefix of a `new format-tag` is fetched from an `existing format-tag`
* If there are no existing format-tags, then prefix `dcterms` is used for the format-tag
* When there are no existing format-tags, the `namespace` for the prefix `dcterms` is added, if not present


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
